### PR TITLE
Update docstring and --help

### DIFF
--- a/hydracheck/cli.py
+++ b/hydracheck/cli.py
@@ -8,9 +8,11 @@ options:
     --channel=CHAN       Channel to check packages for [Default: unstable]
 
 Other channels can be:
-    master
     unstable (Default)
-    19.03 19.09 20.03
+    master
+    19.03
+    19.09
+    20.03
     nixos/release-19.09
 
 


### PR DESCRIPTION
It's not possible to use an argument like `--channel "19.03 19.09 20.03"`; the
previous spacing suggested it might be.

Also puts the default first in the list.