### PR TITLE
Github CI: NixOS/nixpkgs-channels -> NixOS/nixpkgs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,4 +8,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v13
-    - run: nix-build -I nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixpkgs-unstable.tar.gz 
+    - run: nix-build -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixpkgs-unstable.tar.gz 


### PR DESCRIPTION
The nixpkgs-channel repo is archived and only contains an old version. This change updates it to use the one at NixOS/nixpkgs instead