### PR TITLE
Guess channel better

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,6 @@ Build Status for nixpkgs.hello.x86_64-linux on 19.03
 ✔ hello-2.10 from 2019-10-14 - https://hydra.nixos.org/build/103243113
 Build Status for nixpkgs.python.x86_64-linux on 19.03
 ✔ python-2.7.17 from 2020-01-14 - https://hydra.nixos.org/build/110523905
-
-
-$ hydra-check hello --channel nixpkgs/nixpkgs-20.03-darwin --arch=x86_64-darwin
-Build Status for hello.x86_64-darwin on nixpkgs/nixpkgs-20.03-darwin
-✔ hello-2.10 from 2020-04-11 - https://hydra.nixos.org/build/116372067
-
-
 $ hydra-check nixos.tests.installer.simpleUefiGrub --channel 19.09 --arch aarch64-linux
 Build Status for nixos.tests.installer.simpleUefiGrub.aarch64-linux on 19.09
 ✖ (Dependency failed) vm-test-run-installer-simpleUefiGrub from 2020-03-19 - https://hydra.nixos.org/build/115139363

--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ usage: hydra-check [options] PACKAGES...
 ...
 
 $ hydra-check hello
-Build Status for nixpkgs.hello.x86_64-linux on unstable
+Build Status for nixpkgs.hello.x86_64-linux on jobset nixos/trunk-combined
 ✔ hello-2.10 from 2020-03-14 - https://hydra.nixos.org/build/114752982
 
 
 $ hydra-check hello python --channel 19.03
-Build Status for nixpkgs.hello.x86_64-linux on 19.03
+Build Status for nixpkgs.hello.x86_64-linux on jobset nixos/19.03
 ✔ hello-2.10 from 2019-10-14 - https://hydra.nixos.org/build/103243113
-Build Status for nixpkgs.python.x86_64-linux on 19.03
+Build Status for nixpkgs.python.x86_64-linux on jobset nixos/19.03
 ✔ python-2.7.17 from 2020-01-14 - https://hydra.nixos.org/build/110523905
 $ hydra-check nixos.tests.installer.simpleUefiGrub --channel 19.09 --arch aarch64-linux
-Build Status for nixos.tests.installer.simpleUefiGrub.aarch64-linux on 19.09
+Build Status for nixos.tests.installer.simpleUefiGrub.aarch64-linux on jobset nixos/19.09
 ✖ (Dependency failed) vm-test-run-installer-simpleUefiGrub from 2020-03-19 - https://hydra.nixos.org/build/115139363
 
 Last Builds:
@@ -42,7 +42,7 @@ Last Builds:
 
 
 $ hydra-check ugarit --channel 19.09 --short
-Build Status for nixpkgs.ugarit.x86_64-linux on 19.09
+Build Status for nixpkgs.ugarit.x86_64-linux on jobset nixos/19.09
 ✖ (Dependency failed) chicken-ugarit-2.0 from 2020-02-23 - https://hydra.nixos.org/build/108216732
 
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ usage: hydra-check [options] PACKAGES...
 $ hydra-check hello
 Build Status for nixpkgs.hello.x86_64-linux on jobset nixos/trunk-combined
 ✔ hello-2.10 from 2020-03-14 - https://hydra.nixos.org/build/114752982
+$ hydra-check hello --arch x86_64-darwin
+Build Status for hello.x86_64-darwin on jobset nixpkgs/trunk
+✔ hello-2.12.1 from 2023-09-28 - https://hydra.nixos.org/build/236635446
 
 
 $ hydra-check hello python --channel 19.03

--- a/src/hydra_check/arguments.py
+++ b/src/hydra_check/arguments.py
@@ -7,8 +7,8 @@ def process_args() -> argparse.Namespace:
             formatter_class=argparse.RawDescriptionHelpFormatter,
             epilog=textwrap.dedent('''\
                 Other channels can be:
-                    unstable  - alias for nixos/trunk-combined (Default)
-                    master    - alias for nixpkgs/trunk
+                    unstable  - alias for nixos/trunk-combined (Default for Linux architectures)
+                    master    - alias for nixpkgs/trunk (Default for Darwin architectures)
                     staging   - alias for nixos/staging
                     19.03     - alias for nixos/release-19.03
                     19.09     - alias for nixos/release-19.09
@@ -53,6 +53,7 @@ def process_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--channel",
+        # Sort of changes to "master" when arch is darwin
         default="unstable",
         help="Channel to check packages for",
     )

--- a/src/hydra_check/arguments.py
+++ b/src/hydra_check/arguments.py
@@ -13,7 +13,11 @@ def process_args() -> argparse.Namespace:
                     19.03     - alias for nixos/release-19.03
                     19.09     - alias for nixos/release-19.09
                     20.03     - alias for nixos/release-20.03
-                    nixpkgs/nixpkgs-20.03-darwin    - verbatim jobset name
+
+                Usually using the above as --channel arguments, should fit most usages.
+                However, you can use a verbatim jobset name such as:
+
+                    nixpkgs/nixpkgs-20.03-darwin
 
                 Jobset names can be constructed with the project name (e.g. `nixos/` or `nixpkgs/`)
                 followed by a branch name. The available jobsets can be found at:

--- a/src/hydra_check/cli.py
+++ b/src/hydra_check/cli.py
@@ -15,13 +15,16 @@ BuildStatus = Dict[str, Union[str, bool]]
 
 
 # guess functions are intended to be fast without external queries
-def guess_jobset(channel: str) -> str:
+def guess_jobset(channel: str, arch: str) -> str:
     # TODO guess the latest stable channel
     match channel:
         case "master":
             return "nixpkgs/trunk"
         case "unstable":
-            return "nixos/trunk-combined"
+            if arch.endswith("darwin"):
+                return "nixpkgs/trunk"
+            else:
+                return "nixos/trunk-combined"
         case "staging":
             return "nixos/staging"
         case _:
@@ -146,7 +149,7 @@ def main() -> None:
     channel = args.channel
     packages: list[str] = args.PACKAGES
     only_url = args.url
-    jobset = args.jobset or guess_jobset(channel)
+    jobset = args.jobset or guess_jobset(channel, args.arch)
     is_channel = jobset.startswith("nixos/")
     as_json = args.json
     all_builds = {}

--- a/src/hydra_check/cli.py
+++ b/src/hydra_check/cli.py
@@ -185,7 +185,7 @@ def main() -> None:
                     print(Fore.YELLOW, end="")
                 case "✔":
                     print(Fore.GREEN, end="")
-            print(f"Build Status for {package_name} on {channel}")
+            print(f"Build Status for {package_name} on jobset {jobset}")
             print_buildreport(latest)
             if not latest["success"] and latest["evals"] and not args.short:
                 print()


### PR DESCRIPTION
Until now, when I delved into the code, I always got confused with the channels, jobsets, and the architectures. It always annoyed me how these terms are intermingled, and why e.g darwin doesn't use the unstable jobset, and what is the difference between it and `master`...

I also felt as if hydra-check doesn't help me a lot to hide all of these details, because whenever I wanted to check whether a package already fails on Darwin on hydra, I had to open the README, which up until now didn't include a single darwin architecture example, and try out the different jobsets...

Anyway, with the changes here, hopefully users won't be frustrated as I was :). The first 2 commits change only the docs and the `--channel` help text - they make the distinction between channels and jobset a bit clearer. The last commit makes the `--arch` choice affect the default jobset chosen, where darwin is taken into special consideration.