### PR TITLE
Nix: Don't use old, no unneeded darwin sdk packages

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -4,7 +4,6 @@
   pkg-config,
   openssl,
   stdenv,
-  darwin,
   installShellFiles,
 }:
 
@@ -29,14 +28,9 @@ rustPlatform.buildRustPackage {
     installShellFiles
   ];
 
-  buildInputs =
-    [
-      openssl
-    ]
-    ++ lib.optionals stdenv.isDarwin [
-      darwin.apple_sdk.frameworks.Security
-      darwin.apple_sdk.frameworks.SystemConfiguration
-    ];
+  buildInputs = [
+    openssl
+  ];
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd hydra-check \


### PR DESCRIPTION
I verified these are not needed since [the Darwin SDK reform](https://discourse.nixos.org/t/the-darwin-sdks-have-been-updated/55295), on the [Community's Darwin box](https://nix-community.org/community-builder/).