### PR TITLE
fix: erroneous architecture for darwin (macos)

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -111,7 +111,14 @@ impl HydraCheckCli {
             }
             return self;
         }
-        let arch = format!("{}-{}", ARCH, OS);
+        let arch = format!(
+            "{}-{}",
+            ARCH,
+            match OS {
+                "macos" => "darwin", // hack to produce e.g. `aarch64-darwin`
+                x => x,
+            }
+        );
         debug!("assuming --arch '{arch}'");
         warn_if_unknown(&arch);
         Self {


### PR DESCRIPTION
Fix #54. However, this is a dirty hack... I wonder if there is a way to obtain the usual platform double (e.g. `aarch64-darwin`) in rust. Searching...

Friendly ping @doronbehar for review & testing!

**Update:** another solution is to read the [target triple](https://doc.rust-lang.org/cargo/appendix/glossary.html#target) from a `build.rs` script, and then reduce it to a target double. But that seems too much trouble... I think I will stick to the current solution for now.