### PR TITLE
feat: improve packaging, reuse package.nix from nixpkgs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # configured by each user
 .envrc
+.vscode
 
 secrets.py
 runs

--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733229606,
-        "narHash": "sha256-FLYY5M0rpa5C2QAE3CKLYAM6TwbKicdRK6qNrSHlNrE=",
+        "lastModified": 1735268880,
+        "narHash": "sha256-7QEFnKkzD13SPxs+UFR5bUFN2fRw+GlL0am72ZjNre4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "566e53c2ad750c84f6d31f9ccb9d00f823165550",
+        "rev": "7cc0bff31a3a705d3ac4fdceb030a17239412210",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
           nativeBuildInputs = with pkgs.buildPackages; [
             cargo # with shell completions, instead of cargo-auditable
             cargo-insta # for updating insta snapshots
+            clippy # more lints for better rust code
           ] ++ nativeBuildInputs;
 
           env = with pkgs.buildPackages; {

--- a/package.nix
+++ b/package.nix
@@ -1,60 +1,44 @@
 {
   lib,
+  hydra-check,
   rustPlatform,
-  pkg-config,
-  openssl,
-  stdenv,
-  installShellFiles,
   versionCheckHook,
 }:
 
-rustPlatform.buildRustPackage {
-  pname = "hydra-check";
-  version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
+hydra-check.overrideAttrs (
+  {
+    meta ? { },
+    nativeInstallCheckInputs ? [ ],
+    ...
+  }:
+  {
+    version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
 
-  src = builtins.path {
-    name = "hydra-check-source";
-    path = ./.;
-  };
-
-  cargoLock = {
-    lockFile = builtins.path {
-      name = "hydra-check-Cargo.lock";
-      path = ./Cargo.lock;
+    # `builtins.path` works well with lazy trees
+    src = builtins.path {
+      name = "hydra-check-source";
+      path = ./.;
     };
-  };
 
-  nativeBuildInputs = [
-    pkg-config
-    installShellFiles
-  ];
+    cargoDeps = rustPlatform.importCargoLock {
+      lockFile = builtins.path {
+        name = "hydra-check-Cargo.lock";
+        path = ./Cargo.lock;
+      };
+    };
 
-  buildInputs = [
-    openssl
-  ];
-
-  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-    installShellCompletion --cmd hydra-check \
-      --bash <($out/bin/hydra-check --shell-completion bash) \
-      --fish <($out/bin/hydra-check --shell-completion fish) \
-      --zsh <($out/bin/hydra-check --shell-completion zsh)
-  '';
-
-  nativeInstallCheckInputs = [
-    versionCheckHook
-  ];
-
-  doInstallCheck = true;
-
-  meta = {
-    description = "Check hydra for the build status of a package";
-    homepage = "https://github.com/nix-community/hydra-check";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [
-      makefu
-      artturin
-      bryango
+    nativeInstallCheckInputs = nativeInstallCheckInputs ++ [
+      versionCheckHook
     ];
-    mainProgram = "hydra-check";
-  };
-}
+
+    doInstallCheck = true;
+
+    meta = meta // {
+      maintainers = with lib.maintainers; [
+        makefu
+        artturin
+        bryango
+      ];
+    };
+  }
+)

--- a/package.nix
+++ b/package.nix
@@ -5,11 +5,12 @@
   openssl,
   stdenv,
   installShellFiles,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage {
   pname = "hydra-check";
-  version = "2.0.0";
+  version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
 
   src = builtins.path {
     name = "hydra-check-source";
@@ -39,11 +40,21 @@ rustPlatform.buildRustPackage {
       --zsh <($out/bin/hydra-check --shell-completion zsh)
   '';
 
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  doInstallCheck = true;
+
   meta = {
-    description = "scrape hydra for the build status of a package";
-    homepage = "https://github.com/bryango/hydra-check";
+    description = "Check hydra for the build status of a package";
+    homepage = "https://github.com/nix-community/hydra-check";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ bryango ];
+    maintainers = with lib.maintainers; [
+      makefu
+      artturin
+      bryango
+    ];
     mainProgram = "hydra-check";
   };
 }


### PR DESCRIPTION
Now that we have hydra-check in nixpkgs thanks to Doron, we can reuse the improved packaging code and override it with local sources. Also we pull in `clippy` for the devShell for future use.