### PR TITLE
feat: fix --arch for NixOS, improve documentations

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -39,10 +39,7 @@ pub const KNOWN_ARCHITECTURES: [&str; 4] = [
 /// ]);
 /// ```
 ///
-pub const NIXOS_ARCHITECTURES: [&str; 2] = [
-    "x86_64-linux",
-    "aarch64-linux",
-];
+pub const NIXOS_ARCHITECTURES: [&str; 2] = ["x86_64-linux", "aarch64-linux"];
 
 /// Default package filter for the details of a specific evaluation.
 pub const DEFAULT_EVALUATION_FILTER: &str = "nixVersions.stable";

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,9 +1,13 @@
 //! Useful constants shared across the program
 
-/// Currently supported systems on [hydra.nixos.org][hydra].
-/// This may change in the future.
+/// Currently supported systems (`supportedSystems`) on [hydra.nixos.org](https://hydra.nixos.org).
 ///
-/// [hydra]: https://hydra.nixos.org
+/// This is invoked in the jobset: [nixpkgs/trunk](https://hydra.nixos.org/jobset/nixpkgs/trunk#tabs-configuration),
+/// and defined by the following expressions in nixpkgs:
+/// - [pkgs/top-level/release.nix](https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/release.nix)
+/// - [ci/supportedSystems.nix](https://github.com/NixOS/nixpkgs/blob/master/ci/supportedSystems.nix).
+///
+/// This may change in the future.
 ///
 /// ```
 /// assert_eq!(hydra_check::constants::KNOWN_ARCHITECTURES, [
@@ -19,6 +23,25 @@ pub const KNOWN_ARCHITECTURES: [&str; 4] = [
     "aarch64-linux",
     "x86_64-darwin",
     "aarch64-darwin",
+];
+
+/// Currently supported systems (`supportedSystems`) for NixOS.
+///
+/// This is invoked in the jobset: [nixos/trunk-combined](https://hydra.nixos.org/jobset/nixos/trunk-combined#tabs-configuration),
+/// and defined by the expression: [nixpkgs: nixos/release-combined.nix](https://github.com/NixOS/nixpkgs/blob/master/nixos/release-combined.nix).
+///
+/// This may change in the future.
+///
+/// ```
+/// assert_eq!(hydra_check::constants::NIXOS_ARCHITECTURES, [
+///     "x86_64-linux",
+///     "aarch64-linux",
+/// ]);
+/// ```
+///
+pub const NIXOS_ARCHITECTURES: [&str; 2] = [
+    "x86_64-linux",
+    "aarch64-linux",
 ];
 
 /// Default package filter for the details of a specific evaluation.


### PR DESCRIPTION
~~This looks like a huge PR but:~~
- ~~most of it is actually trivial clippy fixes concentrated on the first commit;~~ this is hard to review so I decided to split it off to another future PR;
- the following two commits should fix #60;
- improve documentations & tests such that it would be easier for others to contribute to the guessing logic.

@n8henrie can you see if the fix works? e.g.
```bash
nix run 'github:nix-community/hydra-check?ref=pull/61/merge' -- --arch aarch64-darwin
```