### PR TITLE
feat: apply clippy::pedantic lints & improve CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
     - uses: cachix/install-nix-action@v30
       with:
         nix_path: nixpkgs=channel:nixos-unstable
-    - uses: DeterminateSystems/magic-nix-cache-action@v8
     - run: nix-build
     - run: nix-shell --command 'echo $version' # set in package.nix
 
@@ -38,7 +37,6 @@ jobs:
       with:
         extra_nix_config: |
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-    - uses: DeterminateSystems/magic-nix-cache-action@v8
     - run: nix build --print-build-logs
     - run: nix flake check
     - run: nix develop -c cargo clippy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,14 @@ on:
 jobs:
 
   simple-build:
+    env:
+      CARGO_TERM_COLOR: always
+      TERM: xterm-256color
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # macos-13 for x86_64-darwin
+        os: [ubuntu-latest, macos-13, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -16,11 +21,16 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
     - uses: DeterminateSystems/magic-nix-cache-action@v8
     - run: nix-build
+    - run: nix-shell --command 'echo $version' # set in package.nix
 
   flakes:
+    env:
+      CARGO_TERM_COLOR: always
+      TERM: xterm-256color
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -29,5 +39,8 @@ jobs:
         extra_nix_config: |
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
     - uses: DeterminateSystems/magic-nix-cache-action@v8
-    - run: nix build
+    - run: nix build --print-build-logs
     - run: nix flake check
+    - run: nix develop -c cargo clippy
+    - run: nix develop -c cargo fmt --check --all
+    - run: nix develop -c cargo test --all-features -- --color=always --ignored # run only ignored tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,13 @@
 [package]
 name = "hydra-check"
 version = "2.0.1"
+description = "Check hydra for the build status of a package"
 authors = ["Felix Richter <github@krebsco.de>", "Bryan Lai <bryanlais@gmail.com>"]
 edition = "2021"
+license = "MIT"
+repository = "https://github.com/nix-community/hydra-check"
+keywords = ["cli"]
+categories = ["command-line-utilities"]
 
 [dependencies]
 anyhow = "1.0.89"
@@ -26,3 +31,13 @@ insta = "1.41.1"
 [profile.dev.package]
 insta.opt-level = 3
 similar.opt-level = 3
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+cargo = { level = "warn", priority = -1 }
+manual_string_new = "allow"
+match_bool = "allow"
+single_match = "allow"
+single_match_else = "allow"
+missing_errors_doc = "allow"
+multiple_crate_versions = "allow"

--- a/src/args.rs
+++ b/src/args.rs
@@ -19,7 +19,11 @@ pub(crate) enum Queries {
 
 #[derive(Parser, Debug, Default)]
 #[command(author, version, verbatim_doc_comment)]
-#[allow(rustdoc::bare_urls)]
+#[allow(
+    rustdoc::bare_urls,
+    clippy::doc_markdown,
+    clippy::struct_excessive_bools
+)]
 #[deny(missing_docs)]
 ///
 /// Check hydra.nixos.org for build status of packages

--- a/src/args.rs
+++ b/src/args.rs
@@ -248,7 +248,7 @@ impl HydraCheckCli {
                     );
                     None
                 } else {
-                    Some(self.guess_package_name(&package))
+                    Some(self.guess_package_name(package))
                 }
             })
             .collect()
@@ -256,8 +256,8 @@ impl HydraCheckCli {
 
     fn guess_evals(&self) -> Vec<Evaluation> {
         let mut evals = Vec::new();
-        for spec in self.queries.iter() {
-            evals.push(Evaluation::guess_from_spec(spec))
+        for spec in &self.queries {
+            evals.push(Evaluation::guess_from_spec(spec));
         }
         evals
     }
@@ -342,8 +342,8 @@ impl ResolvedArgs {
                 self.fetch_and_print_jobset(self.short)?;
                 Ok(true)
             }
-            Queries::Packages(packages) => self.fetch_and_print_packages(&packages),
-            Queries::Evals(evals) => self.fetch_and_print_evaluations(&evals),
+            Queries::Packages(packages) => self.fetch_and_print_packages(packages),
+            Queries::Evals(evals) => self.fetch_and_print_evaluations(evals),
         }
     }
 }
@@ -358,7 +358,7 @@ fn guess_jobset() {
     for (channel, jobset) in aliases {
         eprintln!("{channel} => {jobset}");
         let args = HydraCheckCli::parse_from(["hydra-check", "--channel", channel]).guess_jobset();
-        debug_assert_eq!(args.jobset, Some(jobset.into()))
+        debug_assert_eq!(args.jobset, Some(jobset.into()));
     }
 }
 
@@ -379,5 +379,5 @@ fn guess_darwin() {
 #[ignore = "require internet connection"]
 fn guess_stable() {
     let args = HydraCheckCli::parse_from(["hydra-check", "--channel", "stable"]).guess_jobset();
-    eprintln!("{:?}", args.jobset)
+    eprintln!("{:?}", args.jobset);
 }

--- a/src/fetch_stable.rs
+++ b/src/fetch_stable.rs
@@ -54,5 +54,5 @@ fn fetch_stable() {
     println!("latest stable version: {ver}");
     debug_assert!(regex::Regex::new(r"^[0-9]+\.[0-9]+")
         .unwrap()
-        .is_match(&ver))
+        .is_match(&ver));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ trait FetchHydraReport: Clone {
     /// Checks if the fetched [Html] contains a `tbody` tag (table body).
     /// If not, returns the alert text. If yes, returns the found element.
     fn find_tbody<'a>(&self, doc: &'a Html, selector: &str) -> Result<ElementRef<'a>, Self> {
-        let selectors = format!("{} tbody", selector);
+        let selectors = format!("{selector} tbody");
         match doc.find(selectors.trim()) {
             Err(_) => {
                 // either the package was not evaluated (due to being e.g. unfree)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 //!
 //! </div>
 //!
+#![allow(clippy::doc_markdown)]
 #![doc = include_str!("../README.md")]
 
 mod args;

--- a/src/queries/evals.rs
+++ b/src/queries/evals.rs
@@ -134,8 +134,10 @@ fn format_input_changes() {
 }
 
 impl EvalInputChanges {
+    #[allow(clippy::similar_names)]
     fn from_html(doc: &Html) -> anyhow::Result<Vec<Self>> {
         let tables = doc.find_all("div#tabs-inputs table");
+        #[allow(clippy::redundant_closure_for_method_calls)]
         let err = || {
             anyhow!(
                 "could not parse the table of changed inputs in {:?}",
@@ -318,6 +320,7 @@ impl<'a> EvalReport<'a> {
                 })
                 .collect();
             let [name, input_type, value, revision, store_path] = columns.as_slice() else {
+                #[allow(clippy::redundant_else)]
                 if let Ok(true) = is_skipable_row(row) {
                     continue;
                 } else {
@@ -456,6 +459,7 @@ impl ResolvedArgs {
                 (&stat.still_succeed, "Still Succeeding:".bold()),
                 (&stat.unfinished, "Queued Jobs:".bold()),
             ] {
+                #[allow(clippy::uninlined_format_args)]
                 if !build_stats.is_empty() {
                     println!("");
                     println!("{}", prompt);

--- a/src/queries/jobset.rs
+++ b/src/queries/jobset.rs
@@ -62,8 +62,8 @@ impl ShowHydraStatus for EvalStatus {
             let delta = format!(
                 "Δ {}",
                 match self.delta.clone().unwrap_or("~".into()).trim() {
-                    x if x.starts_with("+") => x.green(),
-                    x if x.starts_with("-") => x.red(),
+                    x if x.starts_with('+') => x.green(),
+                    x if x.starts_with('-') => x.red(),
                     x => x.into(),
                 }
             )
@@ -118,7 +118,7 @@ impl<'a> From<&'a ResolvedArgs> for JobsetReport<'a> {
     }
 }
 
-impl<'a> JobsetReport<'a> {
+impl JobsetReport<'_> {
     fn fetch_and_read(self) -> anyhow::Result<Self> {
         let doc = self.fetch_document()?;
         let tbody = match self.find_tbody(&doc, "") {
@@ -162,7 +162,7 @@ impl<'a> JobsetReport<'a> {
             let input_changes = {
                 let text: String = input_changes.text().collect();
                 let text = text.replace(&status, "");
-                let texts: Vec<_> = text.trim().split_whitespace().collect();
+                let texts: Vec<_> = text.split_whitespace().collect();
                 texts.join(" ")
             };
 
@@ -202,7 +202,7 @@ impl<'a> JobsetReport<'a> {
                 failed: Some(failed?),
                 queued: Some(queued?),
                 delta,
-            })
+            });
         }
         Ok(Self { evals, ..self })
     }

--- a/src/queries/jobset.rs
+++ b/src/queries/jobset.rs
@@ -131,6 +131,7 @@ impl<'a> JobsetReport<'a> {
             let [eval_id, timestamp, input_changes, succeeded, failed, queued, delta] =
                 columns.as_slice()
             else {
+                #[allow(clippy::redundant_else)]
                 if is_skipable_row(row)? {
                     continue;
                 } else {

--- a/src/queries/packages.rs
+++ b/src/queries/packages.rs
@@ -65,7 +65,7 @@ impl<'a> PackageReport<'a> {
 }
 
 impl ResolvedArgs {
-    pub(crate) fn fetch_and_print_packages(&self, packages: &Vec<String>) -> anyhow::Result<bool> {
+    pub(crate) fn fetch_and_print_packages(&self, packages: &[String]) -> anyhow::Result<bool> {
         let mut status = true;
         let mut indexmap = IndexMap::new();
         for (idx, package) in packages.iter().enumerate() {
@@ -78,7 +78,7 @@ impl ResolvedArgs {
             if !self.json {
                 // print title first, then fetch
                 if idx > 0 && !self.short {
-                    println!(""); // vertical whitespace
+                    println!(); // vertical whitespace
                 }
                 println!(
                     "Build Status for {} on jobset {}",
@@ -110,7 +110,7 @@ impl ResolvedArgs {
             }
             println!("{}", stat.format_table(self.short, &stat.builds));
             if !success && self.short {
-                warn!("latest build failed, check out: {}", url_dimmed)
+                warn!("latest build failed, check out: {url_dimmed}");
             }
         }
         if self.json {

--- a/src/soup.rs
+++ b/src/soup.rs
@@ -10,7 +10,7 @@ use std::fmt::Debug;
 #[allow(clippy::module_name_repetitions)]
 /// A simple wrapper trait that provides the `find` and `find_all` methods
 /// to [`scraper`]'s [`Selectable`] elements, inspired by the interface of
-/// Python's BeautifulSoup.
+/// Python's `BeautifulSoup`.
 pub trait SoupFind<'a> {
     /// Finds all child elements matching the CSS selectors
     /// and collect them into a [`Vec`].

--- a/src/soup.rs
+++ b/src/soup.rs
@@ -7,6 +7,7 @@ use anyhow::anyhow;
 use scraper::{selectable::Selectable, ElementRef, Html, Selector};
 use std::fmt::Debug;
 
+#[allow(clippy::module_name_repetitions)]
 /// A simple wrapper trait that provides the `find` and `find_all` methods
 /// to [`scraper`]'s [`Selectable`] elements, inspired by the interface of
 /// Python's BeautifulSoup.

--- a/src/structs/builds.rs
+++ b/src/structs/builds.rs
@@ -89,6 +89,7 @@ impl BuildStatus {
             if let [status, build, job_name, timestamp, name, arch] = columns.as_slice() {
                 (status, build, Some(job_name), timestamp, name, arch)
             } else {
+                #[allow(clippy::redundant_else)]
                 if is_skipable_row(row)? {
                     continue;
                 } else {

--- a/src/structs/eval.rs
+++ b/src/structs/eval.rs
@@ -20,7 +20,7 @@ impl Evaluation {
     pub(crate) fn guess_from_spec(spec: &str) -> Self {
         let spec = spec.trim();
 
-        let mut split_spec = spec.splitn(2, "/");
+        let mut split_spec = spec.splitn(2, '/');
         let id = split_spec.next().unwrap().trim();
         let filter = split_spec.next();
 
@@ -85,8 +85,8 @@ fn guess_eval_from_spec() {
         ("rustc", 0, Some("rustc".into())),
         ("weird/filter", 0, Some("weird/filter".into())),
     ] {
-        let eval = Evaluation::guess_from_spec(&spec);
-        println!("{:?}", eval);
+        let eval = Evaluation::guess_from_spec(spec);
+        println!("{eval:?}");
         assert!(eval.id == id && eval.filter == filter);
     }
 }

--- a/src/structs/eval.rs
+++ b/src/structs/eval.rs
@@ -74,6 +74,7 @@ impl Evaluation {
 #[test]
 fn guess_eval_from_spec() {
     let default_filter = constants::DEFAULT_EVALUATION_FILTER;
+    #[allow(clippy::unreadable_literal)]
     for (spec, id, filter) in [
         ("123456", 123456, Some(default_filter.into())),
         ("123456/", 123456, None),


### PR DESCRIPTION
This PR provides:
- more thorough testing via github actions, and
- some functionally trivial changes to improve the rust codebase, guided by the [`clippy::pedantic` lints](https://doc.rust-lang.org/clippy/lints.html).

It would be easy to review commit by commit:
1. [the first commit](https://github.com/nix-community/hydra-check/pull/62/commits/704609715adb7251c9042ef1d23a569a8f9a3cbb) sets up the clippy lints and github actions CI, while
2. [the second commit](https://github.com/nix-community/hydra-check/pull/62/commits/7bd459ff3d58b0272d2a9a3f36e63114d7f50475) actually applies the clippy lints by `cargo clippy --fix` with some manual tweaks for readability.
3. (new) [the third commit](https://github.com/nix-community/hydra-check/pull/62/commits/abd66538d98b285e1019e65e71df850ccd73b573) drops magic nix cache in CI as it's near its end of life: https://determinate.systems/posts/magic-nix-cache-free-tier-eol/

After this, I think we have collected enough minor fixes to justify a new bugfix release, as is hoped for in https://github.com/nix-community/hydra-check/issues/60#issuecomment-2614484615 :laughing: 