### PR TITLE
feat: link to latest success for a failed build

### DIFF
--- a/src/queries/packages.rs
+++ b/src/queries/packages.rs
@@ -109,8 +109,25 @@ impl ResolvedArgs {
                 continue; // print later
             }
             println!("{}", stat.format_table(self.short, &stat.builds));
-            if !success && self.short {
-                warn!("latest build failed, check out: {url_dimmed}");
+            if !success {
+                if self.short {
+                    warn!("latest build failed, check out: {url_dimmed}");
+                } else {
+                    eprintln!("\n{}", "Links:".bold());
+                    #[rustfmt::skip]
+                    eprintln!(
+                        "{} (all builds)",
+                        format!("🔗 {url_dimmed}/all").dimmed()
+                    );
+                    eprintln!(
+                        "{} (latest successful build)",
+                        format!("🔗 {url_dimmed}/latest").dimmed()
+                    );
+                    eprintln!(
+                        "{} (latest success from a finished eval)",
+                        format!("🔗 {url_dimmed}/latest-finished").dimmed()
+                    );
+                }
             }
         }
         if self.json {


### PR DESCRIPTION
This is a trivial quality-of-life improvement that would partially help with #12. See:
- https://github.com/nix-community/hydra-check/issues/12#issuecomment-2644638838

... for more contexts. To test this, try e.g.
```bash
nix run 'github:nix-community/hydra-check?ref=pull/69/merge' -- nixStatic # nix-static has been failing for a while now
```