### PR TITLE
feat(args): allow empty --arch & print --short --json correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,9 +200,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
@@ -724,12 +724,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
 name = "html5ever"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,9 +988,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "linked-hash-map"
@@ -1072,20 +1066,19 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -1150,9 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -1328,9 +1321,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -1783,9 +1776,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1987,9 +1980,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",

--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740547748,
-        "narHash": "sha256-Ly2fBL1LscV+KyCqPRufUBuiw+zmWrlJzpWOWbahplg=",
+        "lastModified": 1744502386,
+        "narHash": "sha256-QAd1L37eU7ktL2WeLLLTmI6P9moz9+a/ONO8qNBYJgM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3a05eebede89661660945da1f151959900903b6a",
+        "rev": "f6db44a8daa59c40ae41ba6e5823ec77fe0d2124",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,9 @@
             nixfmt-rfc-style # for formatting nix code
           ] ++ nativeBuildInputs;
 
+          # use cached crates in "$HOME/.cargo"
+          cargoDeps = pkgs.emptyDirectory;
+
           env = with pkgs.buildPackages; {
             # for developments, e.g. symbol lookup in std library
             RUST_SRC_PATH = "${rustPlatform.rustLibSrc}";

--- a/src/args.rs
+++ b/src/args.rs
@@ -220,7 +220,9 @@ impl HydraCheckCli {
         let arch_suffix = match self.arch.clone() {
             _ if has_known_arch_suffix => "".into(),
             None => warn_unknown_arch(),
-            Some(arch) if arch.is_empty() => warn_unknown_arch(),
+            // empty --arch is useful for aggregate job such as the channel tests
+            // e.g. https://hydra.nixos.org/job/nixpkgs/trunk/unstable
+            Some(arch) if arch.is_empty() => "".into(),
             Some(arch) => format!(".{arch}"),
         };
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -345,7 +345,7 @@ impl ResolvedArgs {
     pub(crate) fn fetch_and_print(&self) -> anyhow::Result<bool> {
         match &self.queries {
             Queries::Jobset => {
-                self.fetch_and_print_jobset(self.short)?;
+                self.fetch_and_print_jobset(false)?;
                 Ok(true)
             }
             Queries::Packages(packages) => self.fetch_and_print_packages(packages),

--- a/src/queries/jobset.rs
+++ b/src/queries/jobset.rs
@@ -209,9 +209,12 @@ impl JobsetReport<'_> {
 }
 
 impl ResolvedArgs {
-    pub(crate) fn fetch_and_print_jobset(&self, summary: bool) -> anyhow::Result<Option<u64>> {
+    pub(crate) fn fetch_and_print_jobset(
+        &self,
+        force_summary: bool,
+    ) -> anyhow::Result<Option<u64>> {
         let stat = JobsetReport::from(self);
-        let (short, json) = match summary {
+        let (short, json) = match force_summary {
             true => (true, false),
             false => (self.short, self.json),
         };


### PR DESCRIPTION
Some minor quality of life improvements:

- Empty --arch is useful for aggregate job such as the channel tests e.g. https://hydra.nixos.org/job/nixpkgs/trunk/unstable, so we should not warn if the user specifies it.
- Previously the --json argument was not correctly passed, therefore the combination of `--short --json` flags would only print a `--short` output. This patch fixes the issue.

Also bumped some dependencies, and improve the release scripts.