### PR TITLE
feat(args): query --releases for channels (plus minor fixes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,6 +798,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "temp-env",
+ "yansi",
 ]
 
 [[package]]
@@ -2494,6 +2495,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ scraper = "0.20.0"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.132"
 serde_with = { version = "3.11.0", default-features = false, features = ["macros"] }
+yansi = { version = "1.0.1", features = ["hyperlink"] }
 
 [dev-dependencies]
 insta = "1.41.1"

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1765121682,
-        "narHash": "sha256-4VBOP18BFeiPkyhy9o4ssBNQEvfvv1kXkasAYd0+rrA=",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
         "owner": "NixOS",
         "repo": "flake-compat",
-        "rev": "65f23138d8d09a92e30f1e5c87611b23ef451bf3",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765934234,
-        "narHash": "sha256-pJjWUzNnjbIAMIc5gRFUuKCDQ9S1cuh3b2hKgA7Mc4A=",
+        "lastModified": 1767026758,
+        "narHash": "sha256-7fsac/f7nh/VaKJ/qm3I338+wAJa/3J57cOGpXi0Sbg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "af84f9d270d404c17699522fab95bbf928a2d92f",
+        "rev": "346dd96ad74dc4457a9db9de4f4f57dab2e5731d",
         "type": "github"
       },
       "original": {

--- a/src/args.rs
+++ b/src/args.rs
@@ -78,6 +78,10 @@ pub struct HydraCheckCli {
     #[arg(short, long)]
     eval: bool,
 
+    /// Query the release tests of the given channel (jobset)
+    #[arg(short, long, conflicts_with = "PACKAGES")]
+    tests: bool,
+
     /// Print more debugging information
     #[arg(short, long)]
     verbose: bool,
@@ -253,6 +257,29 @@ impl HydraCheckCli {
     }
 
     fn guess_packages(&self) -> Vec<String> {
+        if self.tests {
+            let Some(ref jobset) = self.jobset else {
+                error!("--jobset is not properly set up or deduced");
+                std::process::exit(1);
+            };
+            // aggregate job for channel release tests; see the `job` keys in:
+            // - https://github.com/NixOS/infra/blob/main/channels.nix, and
+            // - https://status.nixos.org/
+            //
+            let aggregate_job = match jobset.as_str() {
+                x if x.ends_with("darwin") => "darwin-tested",
+                x if x.starts_with("nixpkgs/") => "unstable",
+                x if x.starts_with("nixos/") => "tested",
+                _ => {
+                    let default = "tested";
+                    warn!(
+                        "unknown --jobset '{jobset}', assuming job '{default}' for release tests"
+                    );
+                    default
+                }
+            };
+            return vec![aggregate_job.into()];
+        }
         self.queries
             .iter()
             .filter_map(|package| {
@@ -328,7 +355,7 @@ impl HydraCheckCli {
         Logger::with(log_level).format(log_format).start()?;
         let args = args.guess_arch();
         let args = args.guess_jobset();
-        let queries = match (args.queries.is_empty(), args.eval) {
+        let queries = match (args.queries.is_empty() && !args.tests, args.eval) {
             (true, false) => Queries::Jobset,
             // this would resolve to the latest eval of a jobset:
             (true, true) => Queries::Evals(vec![Evaluation::guess_from_spec("")]),

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -64,7 +64,7 @@ pub const APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARG
 /// temp_env::with_var(
 ///     "HYDRA_CHECK_HOST_URL", None::<&str>, // when the env var is unset
 ///     || assert_eq!(
-///         &*hydra_check::constants::HYDRA_CHECK_HOST_URL,
+///         *hydra_check::constants::HYDRA_CHECK_HOST_URL,
 ///         "https://hydra.nixos.org"         // ... use the NixOS default
 ///     )                                     // ... otherwise use the env var
 /// );
@@ -72,11 +72,17 @@ pub const APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARG
 ///
 pub static HYDRA_CHECK_HOST_URL: LazyLock<String> = LazyLock::new(get_host_url);
 
+/// Hardcoded default host URL of the official NixOS Hydra instance.
+/// This is intentionally not `pub` so that it cannot be misused outside
+/// this module. They should always use [`HYDRA_CHECK_HOST_URL`] instead.
+///
+const HYDRA_CHECK_DEFAULT_HOST_URL: &str = "https://hydra.nixos.org";
+
 /// Gets the hydra host URL from the environment variable $HYDRA_CHECK_HOST_URL.
 /// Falls back to the default URL if the variable is not set or empty.
 fn get_host_url() -> String {
     let var_name = "HYDRA_CHECK_HOST_URL";
-    let url_default = "https://hydra.nixos.org";
+    let url_default = HYDRA_CHECK_DEFAULT_HOST_URL;
     std::env::var(var_name)
         .ok()
         .map(|url_env| url_env.trim().to_string())
@@ -92,6 +98,10 @@ fn get_host_url() -> String {
             debug!("using default hydra host URL: {url_default}");
             url_default.into()
         })
+}
+
+pub(crate) fn is_default_host_url() -> bool {
+    *HYDRA_CHECK_HOST_URL == HYDRA_CHECK_DEFAULT_HOST_URL
 }
 
 #[test]

--- a/src/queries/builds.rs
+++ b/src/queries/builds.rs
@@ -34,6 +34,7 @@ impl FetchHydraReport for BuildReport {
 }
 
 impl BuildReport {
+    #[must_use]
     pub(super) fn from_url(url: &str) -> Self {
         Self {
             url: url.to_string(),

--- a/src/queries/jobset.rs
+++ b/src/queries/jobset.rs
@@ -16,7 +16,7 @@ pub(crate) struct JobsetReport<'a> {
     jobset: &'a str,
     url: String,
     /// Status of recent evaluations of the jobset
-    evals: Vec<EvalStatus>,
+    pub(crate) evals: Vec<EvalStatus>,
 }
 
 impl FetchHydraReport for JobsetReport<'_> {

--- a/src/queries/packages.rs
+++ b/src/queries/packages.rs
@@ -8,7 +8,7 @@ use std::collections::VecDeque;
 
 use super::builds::BuildReport;
 use crate::{
-    constants::HYDRA_CHECK_HOST_URL,
+    constants,
     queries::jobset::JobsetReport,
     structs::{BuildStatus, EvalStatus, ReleaseStatus},
     FetchHydraReport, ResolvedArgs, StatusIcon,
@@ -54,7 +54,7 @@ impl<'a> PackageReport<'a> {
         //
         let url = format!(
             "{}/job/{}/{package}{}",
-            &*HYDRA_CHECK_HOST_URL,
+            &*constants::HYDRA_CHECK_HOST_URL,
             args.jobset,
             if args.long { "/all" } else { "" }
         );

--- a/src/structs/build.rs
+++ b/src/structs/build.rs
@@ -32,15 +32,15 @@ impl ShowHydraStatus for BuildStatus {
             (true, true) => format!("{icon}"),
         };
         row.push(status.into());
-        match &self.job_name {
-            Some(job_name) => row.push(job_name.as_str().into()),
-            None => {}
+        // job name is only available in some cases (e.g. in eval details)
+        if let Some(x) = self.job_name.as_deref() {
+            row.push(x.into());
         }
         let details = if self.evals {
             let name = self.name.clone().unwrap_or_default().into();
             let timestamp = self
                 .timestamp
-                .clone()
+                .as_deref()
                 .unwrap_or_default()
                 .split_once('T')
                 .unwrap_or_default()

--- a/src/structs/mod.rs
+++ b/src/structs/mod.rs
@@ -2,8 +2,10 @@ mod build;
 mod eval;
 mod icons;
 mod inputs;
+mod release;
 
 pub(crate) use build::BuildStatus;
 pub(crate) use eval::{EvalStatus, Evaluation};
 pub(crate) use icons::StatusIcon;
 pub(crate) use inputs::EvalInput;
+pub(crate) use release::ReleaseStatus;

--- a/src/structs/release.rs
+++ b/src/structs/release.rs
@@ -108,10 +108,15 @@ impl ShowHydraStatus for ReleaseStatus {
 }
 
 impl ReleaseStatus {
-    pub(crate) fn new(eval: EvalStatus, test: BuildStatus, channel: &str) -> Self {
+    pub(crate) fn new(
+        eval: EvalStatus,
+        test: BuildStatus,
+        channel: &str,
+        always_link: bool,
+    ) -> Self {
         let release_url = if constants::is_default_host_url()
             && test.success
-            && eval.finished.unwrap_or_default()
+            && (always_link || eval.finished.unwrap_or_default())
             && (
                 channel.starts_with("nixpkgs-") || channel.starts_with("nixos-")
                 // see: https://channels.nixos.org

--- a/src/structs/release.rs
+++ b/src/structs/release.rs
@@ -9,6 +9,7 @@ use crate::{constants, BuildStatus, EvalStatus, ShowHydraStatus, StatusIcon};
 
 /// Container for the evaluation and test build status of a (potential)
 /// channel release.
+#[non_exhaustive]
 #[skip_serializing_none]
 #[derive(Serialize, Debug, Default, Clone)]
 pub(crate) struct ReleaseStatus {
@@ -112,6 +113,7 @@ impl ReleaseStatus {
         eval: EvalStatus,
         test: BuildStatus,
         channel: &str,
+        jobset: &str,
         always_link: bool,
     ) -> Self {
         let release_url = if constants::is_default_host_url()

--- a/src/structs/release.rs
+++ b/src/structs/release.rs
@@ -1,0 +1,137 @@
+use std::fmt::Display;
+
+use colored::{ColoredString, Colorize};
+use serde::Serialize;
+use serde_with::skip_serializing_none;
+use yansi::hyperlink::HyperlinkExt;
+
+use crate::{constants, BuildStatus, EvalStatus, ShowHydraStatus, StatusIcon};
+
+/// Container for the evaluation and test build status of a (potential)
+/// channel release.
+#[skip_serializing_none]
+#[derive(Serialize, Debug, Default, Clone)]
+pub(crate) struct ReleaseStatus {
+    pub(crate) eval: EvalStatus,
+    pub(crate) test: BuildStatus,
+    pub(crate) release_url: Option<String>,
+}
+
+impl ShowHydraStatus for ReleaseStatus {
+    fn format_as_vec(&self) -> Vec<ColoredString> {
+        fn format_with_optional_hyperlink(expr: impl Display, url: Option<&String>) -> String {
+            let expr = format!("{expr}");
+            match url {
+                Some(url) => expr.link(url).to_string(),
+                None => expr,
+            }
+        }
+        let (eval, test) = (&self.eval, &self.test);
+        let mut row = Vec::new();
+
+        // information about the evaluation
+        let icon = ColoredString::from(&eval.icon);
+        let id_string = eval
+            .id
+            .map(|id| format_with_optional_hyperlink(id, eval.url.as_ref()))
+            .unwrap_or_default();
+        row.push(format!("{icon} {id_string}").into());
+        let name = if test.evals {
+            // if the release test is evaluated, use its name
+            // e.g. nixpkgs-25.11pre854150.5d8f4beac036
+            let name = test.name.as_deref().unwrap_or_default();
+            format_with_optional_hyperlink(name, self.release_url.as_ref())
+        } else if let Some(input_changes) = &eval.input_changes {
+            input_changes.clone()
+        } else {
+            eval.status.clone()
+        };
+        row.push(name.into());
+        let details = if eval.url.is_some() {
+            let timestamp = eval.relative.as_deref().unwrap_or_default().into();
+            let statistics = [
+                (StatusIcon::Succeeded, eval.succeeded),
+                (StatusIcon::Failed, eval.failed),
+                (StatusIcon::Queued, eval.queued),
+            ];
+            let [suceeded, failed, queued] = statistics.map(|(icon, text)| -> ColoredString {
+                format!(
+                    "{} {}",
+                    ColoredString::from(&icon),
+                    text.unwrap_or_default()
+                )
+                .into()
+            });
+            let queued = match eval.queued.unwrap_or_default() {
+                x if x != 0 => queued.bold(),
+                _ => queued.normal(),
+            };
+            let delta = format!(
+                "Δ {}",
+                match eval.delta.clone().unwrap_or("~".into()).trim() {
+                    x if x.starts_with('+') => x.green(),
+                    x if x.starts_with('-') => x.red(),
+                    x => x.into(),
+                }
+            )
+            .into();
+            &[timestamp, suceeded, failed, queued, delta]
+        } else {
+            &Default::default()
+        };
+        row.extend_from_slice(details);
+
+        // information about the test build
+        let icon = ColoredString::from(&test.icon);
+        let test_info = if test.evals {
+            test.timestamp
+                .as_deref()
+                .unwrap_or_default()
+                .split_once('T')
+                .unwrap_or_default()
+                .0
+                .into()
+        } else if let Some(build_id) = &test.build_id {
+            format!("build/{build_id}")
+        } else {
+            "".into()
+        };
+        let test_info_with_url =
+            format_with_optional_hyperlink(&test_info, test.build_url.as_ref());
+        let test_status = match test.evals {
+            false => format!("{icon} {} {test_info_with_url}", test.status),
+            true => format!("{icon} {test_info_with_url}"),
+        };
+        row.push(test_status.into());
+        row
+    }
+}
+
+impl ReleaseStatus {
+    pub(crate) fn new(eval: EvalStatus, test: BuildStatus, channel: &str) -> Self {
+        let release_url = if constants::is_default_host_url()
+            && test.success
+            && eval.finished.unwrap_or_default()
+            && (
+                channel.starts_with("nixpkgs-") || channel.starts_with("nixos-")
+                // see: https://channels.nixos.org
+            ) {
+            Some(format!(
+                "https://releases.nixos.org/{}/{}",
+                if channel == "nixpkgs-unstable" {
+                    "nixpkgs".into()
+                } else {
+                    channel.replacen('-', "/", 1)
+                },
+                test.name.as_deref().unwrap_or_default()
+            ))
+        } else {
+            None
+        };
+        Self {
+            eval,
+            test,
+            release_url,
+        }
+    }
+}


### PR DESCRIPTION
## some background

Release tests are special hydra jobs that determine whether channel updates are okay to be released or instead should be _blocked_. This is nicely described in the wiki page https://wiki.nixos.org/wiki/Channel_branches.

The release tests for all channels are defined [here](https://github.com/NixOS/infra/blob/main/channels.nix) and listed on https://status.nixos.org in the "Hydra job for tests" column, where it also shows the history for each test.

<img width="360" src="https://github.com/user-attachments/assets/7d412392-c396-4e7f-818d-9b035f28e003" />

## motivations & solutions

The ability to query the status of release tests would be valuable for users if we want to pin our local nixpkgs to a "nice" historical commit. These test jobs are similar to usual package jobs in hydra, so we can simply query their status with hydra-check. In previous versions we can already do this manually with e.g.
```
$ hydra-check --channel=nixpkgs-unstable --arch="" unstable
Build Status for unstable on jobset nixpkgs/trunk
https://hydra.nixos.org/job/nixpkgs/trunk/unstable
✔              nixpkgs-25.11pre831594.e821e0319348  2025-07-18  https://hydra.nixos.org/build/303140061
⏹ (Cancelled)  nixpkgs-25.11pre831392.77110a5187ce  2025-07-18  https://hydra.nixos.org/build/303123984
...
```
where we have manually specified the job name "unstable" as the release test for the `nixpkgs-unstable` channel (and `--arch=""` since this is a special job in hydra that does not contain the architecture in its name). The job name may be different for each channel and one needs to look it up on https://status.nixos.org before actually querying it. For example, the release test job name for `nixos-unstable` is called "tested".

This PR adds a new `--releases` flag which automates the above process. Now we can simply do:
```
$ hydra-check --releases
info: fetching recent evals on --channel nixpkgs-unstable for --releases

Build Status for unstable on jobset nixpkgs/trunk
https://hydra.nixos.org/job/nixpkgs/trunk/unstable/all
⧖ 1818491  nixpkgs-25.11pre861192.5c9a8279f372  15h ago     ✔ 255997  ✖ 6036   ⧖ 1835  Δ ~      ⏹ 2025-09-14
✔ 1818483  nixpkgs-25.11pre861040.6d7ec06d6868  23h ago     ✔ 257693  ✖ 6144   ⧖ 0     Δ +14    ✔ 2025-09-13
...
```
which is equivalent to the previous query, combined with information of recent channel evals, basically providing the same information as in https://status.nixos.org.

~~Along the way, we also improve channel guessing by preferring `nixpkgs-XX.XX-darwin` on darwin (instead of `nixos/release-XX.XX` which was the previous default). This is arranged in a separate commit.~~

**Update:** this PR has grown too large so I will be cherry-picking parts of it and merge them step by step. These include the quality of life improvements in #84. Expect the number of commits here to decrease after these minor updates are merged into master.