### PR TITLE
 fix(deps): work around compiler bug for rust 1.88 

### DIFF
--- a/fix-cargo-1_88-reqwest.patch
+++ b/fix-cargo-1_88-reqwest.patch
@@ -1,0 +1,15 @@
+diff --git a/Cargo.toml b/Cargo.toml
+index bb8d370..7c5b7ac 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -35,6 +35,10 @@ anyhow = "1.0.89"
+ insta.opt-level = 3
+ similar.opt-level = 3
+ 
++# work around https://github.com/NixOS/nixpkgs/issues/427072
++[profile.release.package.hyper]
++opt-level = 0
++
+ [lints.clippy]
+ pedantic = { level = "warn", priority = -1 }
+ cargo = { level = "warn", priority = -1 }

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744502386,
-        "narHash": "sha256-QAd1L37eU7ktL2WeLLLTmI6P9moz9+a/ONO8qNBYJgM=",
+        "lastModified": 1752747119,
+        "narHash": "sha256-2Kp9St3Pbsmu+xMsobLcgzzUxPvZR7alVJWyuk2BAPc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f6db44a8daa59c40ae41ba6e5823ec77fe0d2124",
+        "rev": "fa0ef8a6bb1651aa26c939aeb51b5f499e86b0ec",
         "type": "github"
       },
       "original": {

--- a/package.nix
+++ b/package.nix
@@ -1,7 +1,9 @@
 {
   lib,
+  stdenv,
   hydra-check,
   rustPlatform,
+  buildPackages,
   source ? builtins.path {
     # `builtins.path` works well with lazy trees
     name = "hydra-check-source";
@@ -28,8 +30,7 @@ hydra-check.overrideAttrs (
   {
     version,
     meta ? { },
-    nativeBuildInputs ? [ ],
-    nativeInstallCheckInputs ? [ ],
+    patches ? [ ],
     ...
   }:
   {
@@ -39,6 +40,12 @@ hydra-check.overrideAttrs (
         than the one provided in nixpkgs (${version}).
       '';
       newVersion;
+
+    patches =
+      patches
+      ++ lib.optional (
+        lib.hasPrefix "1.88" buildPackages.rustc.version && stdenv.buildPlatform.system == "x86_64-darwin"
+      ) ./fix-cargo-1_88-reqwest.patch;
 
     src = source;
 


### PR DESCRIPTION
Closes #79.

This is a band-aid that works around the compiler / linker bug discussed in https://github.com/nix-community/hydra-check/issues/79#issuecomment-3095000151.

@mirkolenz could you test if this works? If so I will also upstream it to nixpkgs. You can also apply it on top of your local nixpkgs with an `.overrideAttrs`, similar to what is done [here in package.nix](https://github.com/nix-community/hydra-check/pull/80/files).