### PR TITLE
chore(nix): bump nixpkgs & update package.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1752747119,
-        "narHash": "sha256-2Kp9St3Pbsmu+xMsobLcgzzUxPvZR7alVJWyuk2BAPc=",
+        "lastModified": 1753750875,
+        "narHash": "sha256-J1P0aQymehe8AHsID9wwoMjbaYrIB2eH5HftoXhF9xk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fa0ef8a6bb1651aa26c939aeb51b5f499e86b0ec",
+        "rev": "871381d997e4a063f25a3994ce8a9ac595246610",
         "type": "github"
       },
       "original": {

--- a/package.nix
+++ b/package.nix
@@ -1,9 +1,7 @@
 {
   lib,
-  stdenv,
   hydra-check,
   rustPlatform,
-  buildPackages,
   source ? builtins.path {
     # `builtins.path` works well with lazy trees
     name = "hydra-check-source";
@@ -30,7 +28,6 @@ hydra-check.overrideAttrs (
   {
     version,
     meta ? { },
-    patches ? [ ],
     ...
   }:
   {
@@ -40,12 +37,6 @@ hydra-check.overrideAttrs (
         than the one provided in nixpkgs (${version}).
       '';
       newVersion;
-
-    patches =
-      patches
-      ++ lib.optional (
-        lib.hasPrefix "1.88" buildPackages.rustc.version && stdenv.buildPlatform.system == "x86_64-darwin"
-      ) ./fix-cargo-1_88-reqwest.patch;
 
     src = source;
 


### PR DESCRIPTION
Closes #79 as the workaround has been upstreamed to nixpkgs.