### PR TITLE
fix(args): prefer nixpkgs-XX.XX-darwin on darwin, and refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -853,16 +853,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.9"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
+checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
 dependencies = [
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "libc",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1462,9 +1464,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.8"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
+checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "async-compression",
  "base64",
@@ -1500,6 +1502,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-util",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2026,6 +2029,27 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"

--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1753750875,
-        "narHash": "sha256-J1P0aQymehe8AHsID9wwoMjbaYrIB2eH5HftoXhF9xk=",
+        "lastModified": 1756911493,
+        "narHash": "sha256-6n/n1GZQ/vi+LhFXMSyoseKdNfc2QQaSBXJdgamrbkE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "871381d997e4a063f25a3994ce8a9ac595246610",
+        "rev": "c6a788f552b7b7af703b1a29802a7233c0067908",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,10 @@
           default = self.packages.${system}.hydra-check;
         };
 
-        devShells.default = self.packages.${system}.hydra-check.overrideAttrs ({ nativeBuildInputs, ... }: {
+        devShells.default = (self.packages.${system}.hydra-check.override {
+          # prevent dependence on the source ./.; see ./package.nix
+          source = null;
+        }).overrideAttrs ({ nativeBuildInputs ? [], env ? {}, ... }: {
           nativeBuildInputs = with pkgs.buildPackages; [
             git
             cargo # with shell completions, instead of cargo-auditable
@@ -30,10 +33,7 @@
             nixfmt-rfc-style # for formatting nix code
           ] ++ nativeBuildInputs;
 
-          # use cached crates in "$HOME/.cargo"
-          cargoDeps = pkgs.emptyDirectory;
-
-          env = with pkgs.buildPackages; {
+          env = with pkgs.buildPackages; env // {
             # for developments, e.g. symbol lookup in std library
             RUST_SRC_PATH = "${rustPlatform.rustLibSrc}";
             # for debugging

--- a/src/args.rs
+++ b/src/args.rs
@@ -102,7 +102,7 @@ impl HydraCheckCli {
             if !Vec::from(constants::KNOWN_ARCHITECTURES).contains(&arch) {
                 warn!(
                     "unknown --arch '{arch}', {}: {:#?}",
-                    "consider specify one of the following known architectures",
+                    "consider specifying one of the following known architectures",
                     constants::KNOWN_ARCHITECTURES
                 );
             }

--- a/src/queries/jobset.rs
+++ b/src/queries/jobset.rs
@@ -209,12 +209,17 @@ impl JobsetReport<'_> {
 }
 
 impl ResolvedArgs {
+    /// - Returns the latest evaluation ID if available.
+    /// - Forces `--short` output if `force_short_output` is true.
+    ///   This _was_ used with `--eval` to avoid long outputs, but it turns out
+    ///   that detailed jobset information is practically useful, so this
+    ///   toggle is currently unused.
     pub(crate) fn fetch_and_print_jobset(
         &self,
-        force_summary: bool,
+        force_short_output: bool,
     ) -> anyhow::Result<Option<u64>> {
         let stat = JobsetReport::from(self);
-        let (short, json) = match force_summary {
+        let (short, json) = match force_short_output {
             true => (true, false),
             false => (self.short, self.json),
         };

--- a/src/structs/build.rs
+++ b/src/structs/build.rs
@@ -35,7 +35,7 @@ impl ShowHydraStatus for BuildStatus {
         match &self.job_name {
             Some(job_name) => row.push(job_name.as_str().into()),
             None => {}
-        };
+        }
         let details = if self.evals {
             let name = self.name.clone().unwrap_or_default().into();
             let timestamp = self


### PR DESCRIPTION
A pack of small quality of life improvements including:
- prefer nixpkgs-XX.XX-darwin on stable darwin (as it should)
- expose --channel internally for future use with releases.nixos.org
- cache nixpkgs stable version, improving performance
- refactor some code for future convenience
- bump dependencies and build specs