### PR TITLE
ci(github): bump intel mac runner to macos-15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-13 for x86_64-darwin
-        os: [ubuntu-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, macos-15-intel, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v5
@@ -29,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, macos-15-intel, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
`macos-13` runner is now deprecated. This may or may not resolve the CI failure seen in #85.

**Update:** it seems that magic-nix-cache was falsely downloading the arm binary for x86 mac. This has now been fixed upstream.