### PR TITLE
chore: bump nixpkgs, improve ci, trunk -> unstable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,4 +45,4 @@ jobs:
     - run: nix flake check
     - run: nix develop -c cargo clippy
     - run: nix develop -c cargo fmt --check --all
-    - run: nix develop -c cargo test --all-features -- --color=always --ignored # run only ignored tests
+    - run: nix develop -c cargo test --all-features -- --color=always --no-capture --ignored # run only ignored tests

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ usage: hydra-check [options] PACKAGES...
 ...
 
 $ hydra-check
-Evaluations of jobset nixpkgs/trunk @ https://hydra.nixos.org/jobset/nixpkgs/trunk/evals
+Evaluations of jobset nixpkgs/unstable @ https://hydra.nixos.org/jobset/nixpkgs/unstable/evals
 ⧖ nixpkgs → df76cd6  5h ago      ✔ 194306  ✖ 3554   ⧖ 55364  Δ ?       https://hydra.nixos.org/eval/1809865
 ⧖ nixpkgs → 7701a9e  14h ago     ✔ 196874  ✖ 5123   ⧖ 51253  Δ ?       https://hydra.nixos.org/eval/1809859
 ⧖ nixpkgs → 7150b43  23h ago     ✔ 200232  ✖ 48388  ⧖ 4629   Δ ?       https://hydra.nixos.org/eval/1809854
@@ -28,11 +28,11 @@ Evaluations of jobset nixpkgs/trunk @ https://hydra.nixos.org/jobset/nixpkgs/tru
 ...
 
 $ hydra-check hello
-Build Status for nixpkgs.hello.x86_64-linux on jobset nixos/trunk-combined
+Build Status for nixpkgs.hello.x86_64-linux on jobset nixos/unstable
 ✔ hello-2.10 from 2020-03-14 - https://hydra.nixos.org/build/114752982
 
 $ hydra-check hello --arch x86_64-darwin
-Build Status for hello.x86_64-darwin on jobset nixpkgs/trunk
+Build Status for hello.x86_64-darwin on jobset nixpkgs/unstable
 ✔ hello-2.12.1 from 2023-09-28 - https://hydra.nixos.org/build/236635446
 
 $ hydra-check hello python --channel 19.03
@@ -157,7 +157,7 @@ Queued Jobs:
 - `--arch` defaults to the target architecture (instead of `x86_64-linux` all the time)
 - `--jobset` explicitly conflicts with `--channel` to avoid confusion, as channels are just aliases for jobsets
 - The `staging` channel / alias is removed as `nixos/staging` is no longer active; instead we add `staging-next` as an alias for `nixpkgs/staging-next`
-- The default `unstable` channel points to `nixpkgs/trunk` on non-NixOS systems
+- The default `unstable` channel points to `nixpkgs/unstable` on non-NixOS systems
 
 # Features
 - Print recent evaluations of the jobset if no package is specified

--- a/flake.lock
+++ b/flake.lock
@@ -3,15 +3,15 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1747046372,
-        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
-        "owner": "edolstra",
+        "lastModified": 1765121682,
+        "narHash": "sha256-4VBOP18BFeiPkyhy9o4ssBNQEvfvv1kXkasAYd0+rrA=",
+        "owner": "NixOS",
         "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "rev": "65f23138d8d09a92e30f1e5c87611b23ef451bf3",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
+        "owner": "NixOS",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756911493,
-        "narHash": "sha256-6n/n1GZQ/vi+LhFXMSyoseKdNfc2QQaSBXJdgamrbkE=",
+        "lastModified": 1765934234,
+        "narHash": "sha256-pJjWUzNnjbIAMIc5gRFUuKCDQ9S1cuh3b2hKgA7Mc4A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c6a788f552b7b7af703b1a29802a7233c0067908",
+        "rev": "af84f9d270d404c17699522fab95bbf928a2d92f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     flake-compat = {
-      url = "github:edolstra/flake-compat";
+      url = "github:NixOS/flake-compat";
       flake = false;
     };
   };

--- a/src/args.rs
+++ b/src/args.rs
@@ -31,8 +31,8 @@ pub(crate) enum Queries {
 /// Check hydra.nixos.org for build status of packages
 ///
 /// Other channels can be:
-///   - unstable      - alias for nixos/trunk-combined (for NixOS) or nixpkgs/trunk
-///   - master        - alias for nixpkgs/trunk (Default for other architectures)
+///   - unstable      - alias for nixos/unstable (for NixOS) or nixpkgs/unstable
+///   - master        - alias for nixpkgs/unstable (Default for other architectures)
 ///   - staging-next  - alias for nixpkgs/staging-next
 ///   - 24.05         - alias for nixos/release-24.05
 ///
@@ -191,8 +191,8 @@ impl HydraCheckCli {
         };
         debug!("--channel resolves to '{channel}'");
         let jobset: String = match channel.as_str() {
-            "nixpkgs-unstable" => "nixpkgs/trunk".into(),
-            "nixos-unstable" => "nixos/trunk-combined".into(),
+            "nixpkgs-unstable" => "nixpkgs/unstable".into(),
+            "nixos-unstable" => "nixos/unstable".into(),
             "nixos-unstable-small" => "nixos/unstable-small".into(),
             x if x.starts_with("staging-next") => format!("nixpkgs/{x}"),
             x if Regex::new(r"^nixos-[0-9]+\.[0-9]+").unwrap().is_match(x) => {
@@ -234,7 +234,7 @@ impl HydraCheckCli {
             _ if has_known_arch_suffix => "".into(),
             None => warn_unknown_arch(),
             // empty --arch is useful for aggregate job such as the channel tests
-            // e.g. https://hydra.nixos.org/job/nixpkgs/trunk/unstable
+            // e.g. https://hydra.nixos.org/job/nixpkgs/unstable/unstable
             Some(arch) if arch.is_empty() => "".into(),
             Some(arch) => format!(".{arch}"),
         };
@@ -391,7 +391,7 @@ fn guess_darwin() {
     }
     let args = HydraCheckCli::parse_from(["hydra-check", "--arch", apple_silicon]).guess_jobset();
     // always follow nixpkgs-unstable
-    debug_assert_eq!(args.jobset, Some("nixpkgs/trunk".into()));
+    debug_assert_eq!(args.jobset, Some("nixpkgs/unstable".into()));
 }
 
 #[test]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,7 +5,7 @@ use std::sync::LazyLock;
 
 /// Currently supported systems (`supportedSystems`) on [hydra.nixos.org](https://hydra.nixos.org).
 ///
-/// This is invoked in the jobset: [nixpkgs/trunk](https://hydra.nixos.org/jobset/nixpkgs/trunk#tabs-configuration),
+/// This is invoked in the jobset: [nixpkgs/unstable](https://hydra.nixos.org/jobset/nixpkgs/unstable#tabs-configuration),
 /// and defined by the following expressions in nixpkgs:
 /// - [pkgs/top-level/release.nix](https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/release.nix)
 /// - [ci/supportedSystems.nix](https://github.com/NixOS/nixpkgs/blob/master/ci/supportedSystems.nix).
@@ -30,7 +30,7 @@ pub const KNOWN_ARCHITECTURES: [&str; 4] = [
 
 /// Currently supported systems (`supportedSystems`) for NixOS.
 ///
-/// This is invoked in the jobset: [nixos/trunk-combined](https://hydra.nixos.org/jobset/nixos/trunk-combined#tabs-configuration),
+/// This is invoked in the jobset: [nixos/unstable](https://hydra.nixos.org/jobset/nixos/unstable#tabs-configuration),
 /// and defined by the expression: [nixpkgs: nixos/release-combined.nix](https://github.com/NixOS/nixpkgs/blob/master/nixos/release-combined.nix).
 ///
 /// This may change in the future.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ trait ShowHydraStatus {
 
 /// Trait for all kinds of Hydra `Report`.
 /// This usually corresponds to a summary page from Hydra's web interface,
-/// such as <https://hydra.nixos.org/job/nixpkgs/trunk/hello.x86_64-linux>.
+/// such as <https://hydra.nixos.org/job/nixpkgs/unstable/hello.x86_64-linux>.
 trait FetchHydraReport: Clone {
     fn get_url(&self) -> &str;
     fn fetch_document(&self) -> anyhow::Result<Html> {

--- a/src/queries/jobset.rs
+++ b/src/queries/jobset.rs
@@ -1,5 +1,5 @@
 //! A module that formats the details of the specified (or inferred) jobset,
-//! from an url like: <https://hydra.nixos.org/jobset/nixpkgs/trunk/evals>.
+//! from an url like: <https://hydra.nixos.org/jobset/nixpkgs/unstable/evals>.
 
 use anyhow::bail;
 use colored::{ColoredString, Colorize};
@@ -108,7 +108,7 @@ impl FetchHydraReport for JobsetReport<'_> {
 impl<'a> From<&'a ResolvedArgs> for JobsetReport<'a> {
     fn from(args: &'a ResolvedArgs) -> Self {
         //
-        // https://hydra.nixos.org/jobset/nixpkgs/trunk/evals
+        // https://hydra.nixos.org/jobset/nixpkgs/unstable/evals
         //
         let url = format!("{}/jobset/{}/evals", &*HYDRA_CHECK_HOST_URL, args.jobset);
         Self {

--- a/src/queries/packages.rs
+++ b/src/queries/packages.rs
@@ -1,5 +1,5 @@
 //! A module that formats the details of the specified (or inferred) packages,
-//! e.g. from <https://hydra.nixos.org/job/nixpkgs/trunk/hello.x86_64-linux>.
+//! e.g. from <https://hydra.nixos.org/job/nixpkgs/unstable/hello.x86_64-linux>.
 
 use colored::Colorize;
 use indexmap::IndexMap;
@@ -45,7 +45,7 @@ impl<'a> PackageReport<'a> {
         // Examples:
         // - https://hydra.nixos.org/job/nixos/release-19.09/nixpkgs.hello.x86_64-linux/latest
         // - https://hydra.nixos.org/job/nixos/release-19.09/nixos.tests.installer.simpleUefiGrub.aarch64-linux
-        // - https://hydra.nixos.org/job/nixpkgs/trunk/hello.x86_64-linux/all
+        // - https://hydra.nixos.org/job/nixpkgs/unstable/hello.x86_64-linux/all
         //
         // There is also {url}/all which is a lot slower.
         //


### PR DESCRIPTION
Upstream has changed the cryptic `trunk` job names to `unstable` which is directly related to the channel names.

See: https://github.com/NixOS/infra/commit/3f8810bcb657f0145e1818db2dea0691a9d54b18