### PR TITLE
feat: minor improvements of query resolution & version caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,6 +790,7 @@ dependencies = [
  "indexmap",
  "insta",
  "log",
+ "once_cell",
  "regex",
  "reqwest",
  "scraper",
@@ -1155,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ comfy-table = { version = "7.1.1", features = ["custom_styling"] }
 flexi_logger = "0.29.3"
 indexmap = { version = "2.6.0", features = ["serde"] }
 log = "0.4.22"
+once_cell = "1.21.3"
 regex = "1.11.0"
 reqwest = { version = "0.12.8", features = ["blocking", "cookies", "gzip"] }
 scraper = "0.20.0"

--- a/src/args.rs
+++ b/src/args.rs
@@ -190,7 +190,7 @@ impl HydraCheckCli {
                         std::process::exit(1);
                     }
                 };
-                channel_stable(&version)
+                channel_stable(version)
             }
             x if Regex::new(r"^[0-9]+\.[0-9]+$").unwrap().is_match(x) => channel_stable(x),
             x => x.into(),

--- a/src/args.rs
+++ b/src/args.rs
@@ -194,7 +194,11 @@ impl HydraCheckCli {
             "nixpkgs-unstable" => "nixpkgs/trunk".into(),
             "nixos-unstable" => "nixos/trunk-combined".into(),
             "nixos-unstable-small" => "nixos/unstable-small".into(),
-            x if x.starts_with("staging-next") => format!("nixpkgs/{x}"),
+            // https://hydra.nixos.org/project/nixos
+            x if x.starts_with("staging") && x.ends_with("-small") => format!("nixos/{x}"),
+            // `nixos/staging` is abandoned while `nixpkgs/staging` is active
+            // https://hydra.nixos.org/project/nixpkgs
+            x if x.starts_with("staging") => format!("nixpkgs/{x}"),
             x if Regex::new(r"^nixos-[0-9]+\.[0-9]+").unwrap().is_match(x) => {
                 x.replacen("nixos", "nixos/release", 1)
             }
@@ -373,6 +377,12 @@ fn guess_jobset() {
         ("24.05", "nixos/release-24.05"),
         ("nixos-23.05", "nixos/release-23.05"),
         ("nixos-23.11-small", "nixos/release-23.11-small"),
+        ("nixpkgs-25.05-darwin", "nixpkgs/nixpkgs-25.05-darwin"),
+        ("staging", "nixpkgs/staging"),
+        ("staging-next", "nixpkgs/staging-next"),
+        ("staging-next-small", "nixos/staging-next-small"),
+        ("staging-next-24.11", "nixpkgs/staging-next-24.11"),
+        ("staging-next-24.11-small", "nixos/staging-next-24.11-small"),
     ];
     for (channel, jobset) in aliases {
         eprintln!("{channel} => {jobset}");
@@ -397,6 +407,20 @@ fn guess_darwin() {
 #[test]
 #[ignore = "require internet connection"]
 fn guess_stable() {
-    let args = HydraCheckCli::parse_from(["hydra-check", "--channel", "stable"]).guess_jobset();
+    let args: HydraCheckCli =
+        HydraCheckCli::parse_from(["hydra-check", "--channel", "stable"]).guess_jobset();
     eprintln!("{:?}", args.jobset);
+    assert!(args.jobset.is_some_and(|x| x.starts_with("nixos/release-")));
+    let args: HydraCheckCli = HydraCheckCli::parse_from([
+        "hydra-check",
+        "--channel",
+        "stable",
+        "--arch",
+        "aarch64-darwin", // apple silicon
+    ])
+    .guess_jobset();
+    eprintln!("{:?}", args.jobset);
+    assert!(args
+        .jobset
+        .is_some_and(|x| x.starts_with("nixpkgs/nixpkgs-") && x.ends_with("darwin")));
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -64,7 +64,7 @@ pub struct HydraCheckCli {
 
     /// Fetch more entries if possible (might be slower)
     #[arg(short, long, conflicts_with = "short")]
-    more: bool,
+    long: bool,
 
     /// System architecture to check
     #[arg(short, long)]
@@ -100,7 +100,7 @@ pub(crate) struct ResolvedArgs {
     pub(crate) url: bool,
     pub(crate) json: bool,
     pub(crate) short: bool,
-    pub(crate) more: bool,
+    pub(crate) long: bool,
     pub(crate) jobset: String,
 }
 
@@ -282,7 +282,7 @@ impl HydraCheckCli {
     fn guess_evals(&self) -> Vec<Evaluation> {
         let mut evals = Vec::new();
         for spec in &self.queries {
-            evals.push(Evaluation::guess_from_spec(spec, self.more));
+            evals.push(Evaluation::guess_from_spec(spec, self.long));
         }
         evals
     }
@@ -341,7 +341,7 @@ impl HydraCheckCli {
         let queries = match (args.queries.is_empty(), args.eval) {
             (true, false) => Queries::Jobset,
             // this would resolve to the latest eval of a jobset:
-            (true, true) => Queries::Evals(vec![Evaluation::guess_from_spec("", args.more)]),
+            (true, true) => Queries::Evals(vec![Evaluation::guess_from_spec("", args.long)]),
             (false, true) => Queries::Evals(args.guess_evals()),
             (false, false) => Queries::Packages(args.guess_packages()),
         };
@@ -350,7 +350,7 @@ impl HydraCheckCli {
             url: args.url,
             json: args.json,
             short: args.short,
-            more: args.more,
+            long: args.long,
             jobset: args
                 .jobset
                 .expect("jobset should be resolved by `guess_jobset()`"),

--- a/src/queries/evals.rs
+++ b/src/queries/evals.rs
@@ -212,11 +212,15 @@ impl FetchHydraReport for EvalReport<'_> {
 
 impl<'a> From<&'a Evaluation> for EvalReport<'a> {
     fn from(eval: &'a Evaluation) -> Self {
-        let url = format!("{}/eval/{}", &*HYDRA_CHECK_HOST_URL, eval.id);
-        let url = match &eval.filter {
-            Some(x) => format!("{url}?filter={x}"),
-            None => url,
-        };
+        let mut url = format!("{}/eval/{}", &*HYDRA_CHECK_HOST_URL, eval.id);
+        let mut filtered = false;
+        if let Some(filter) = &eval.filter {
+            url = format!("{url}?filter={filter}");
+            filtered = true;
+        }
+        if eval.more {
+            url = format!("{url}{}full=1", if filtered { "&" } else { "?" });
+        }
         Self {
             eval,
             url,

--- a/src/queries/evals.rs
+++ b/src/queries/evals.rs
@@ -218,7 +218,7 @@ impl<'a> From<&'a Evaluation> for EvalReport<'a> {
             url = format!("{url}?filter={filter}");
             filtered = true;
         }
-        if eval.more {
+        if eval.long {
             url = format!("{url}{}full=1", if filtered { "&" } else { "?" });
         }
         Self {

--- a/src/queries/packages.rs
+++ b/src/queries/packages.rs
@@ -49,7 +49,12 @@ impl<'a> PackageReport<'a> {
         //
         // There is also {url}/all which is a lot slower.
         //
-        let url = format!("{}/job/{}/{}", &*HYDRA_CHECK_HOST_URL, args.jobset, package);
+        let url = format!(
+            "{}/job/{}/{package}{}",
+            &*HYDRA_CHECK_HOST_URL,
+            args.jobset,
+            if args.more { "/all" } else { "" }
+        );
         Self {
             package,
             url,
@@ -113,6 +118,7 @@ impl ResolvedArgs {
                 continue; // print later
             }
             println!("{}", stat.format_table(self.short, &stat.builds));
+            let url_stripped = stat.get_url().trim_end_matches("/all");
             if !success {
                 if self.short {
                     info!("latest build failed, check out: {url_dimmed}");
@@ -121,22 +127,22 @@ impl ResolvedArgs {
                     #[rustfmt::skip]
                     eprintln!(
                         "{} (all builds)",
-                        format!("🔗 {url_dimmed}/all").dimmed()
+                        format!("🔗 {url_stripped}/all").dimmed()
                     );
                     eprintln!(
                         "{} (latest successful build)",
-                        format!("🔗 {url_dimmed}/latest").dimmed()
+                        format!("🔗 {url_stripped}/latest").dimmed()
                     );
                     eprintln!(
                         "{} (latest success from a finished eval)",
-                        format!("🔗 {url_dimmed}/latest-finished").dimmed()
+                        format!("🔗 {url_stripped}/latest-finished").dimmed()
                     );
 
                     eprintln!();
                 }
                 info!("showing inputs for the latest success from a finished eval...");
 
-                let url = format!("{}/latest-finished", stat.get_url());
+                let url = format!("{url_stripped}/latest-finished");
                 let build_report = BuildReport::from_url(&url);
                 let build_report = build_report.fetch_and_read()?;
                 for entry in &build_report.inputs {

--- a/src/queries/packages.rs
+++ b/src/queries/packages.rs
@@ -53,7 +53,7 @@ impl<'a> PackageReport<'a> {
             "{}/job/{}/{package}{}",
             &*HYDRA_CHECK_HOST_URL,
             args.jobset,
-            if args.more { "/all" } else { "" }
+            if args.long { "/all" } else { "" }
         );
         Self {
             package,

--- a/src/structs/eval.rs
+++ b/src/structs/eval.rs
@@ -13,11 +13,12 @@ pub(crate) struct Evaluation {
     pub(crate) spec: String,
     pub(crate) id: u64,
     pub(crate) filter: Option<String>,
+    pub(crate) more: bool,
 }
 
 impl Evaluation {
     /// Parses an evaluation from a plain text specification.
-    pub(crate) fn guess_from_spec(spec: &str) -> Self {
+    pub(crate) fn guess_from_spec(spec: &str, more: bool) -> Self {
         let spec = spec.trim();
 
         let mut split_spec = spec.splitn(2, '/');
@@ -67,6 +68,7 @@ impl Evaluation {
             ),
             id,
             filter,
+            more,
         }
     }
 }
@@ -85,7 +87,7 @@ fn guess_eval_from_spec() {
         ("rustc", 0, Some("rustc".into())),
         ("weird/filter", 0, Some("weird/filter".into())),
     ] {
-        let eval = Evaluation::guess_from_spec(spec);
+        let eval = Evaluation::guess_from_spec(spec, false);
         println!("{eval:?}");
         assert!(eval.id == id && eval.filter == filter);
     }

--- a/src/structs/eval.rs
+++ b/src/structs/eval.rs
@@ -13,12 +13,12 @@ pub(crate) struct Evaluation {
     pub(crate) spec: String,
     pub(crate) id: u64,
     pub(crate) filter: Option<String>,
-    pub(crate) more: bool,
+    pub(crate) long: bool,
 }
 
 impl Evaluation {
     /// Parses an evaluation from a plain text specification.
-    pub(crate) fn guess_from_spec(spec: &str, more: bool) -> Self {
+    pub(crate) fn guess_from_spec(spec: &str, long: bool) -> Self {
         let spec = spec.trim();
 
         let mut split_spec = spec.splitn(2, '/');
@@ -68,7 +68,7 @@ impl Evaluation {
             ),
             id,
             filter,
-            more,
+            long,
         }
     }
 }


### PR DESCRIPTION
These are some quality of life changes cherry-picked from #78.

- query resolution: add more support for staging & darwin (more tests)
- `--more` flag: fetch more entries when needed, useful for #78
- improve (and simplify) stable version caching with `once_cell` (better than std `OnceLock`)