### PR TITLE
build(release): v2.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,7 +779,7 @@ checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "hydra-check"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydra-check"
-version = "2.0.4"
+version = "2.0.5"
 description = "Check hydra for the build status of a package"
 authors = ["Felix Richter <github@krebsco.de>", "Bryan Lai <bryanlais@gmail.com>"]
 edition = "2021"

--- a/package.nix
+++ b/package.nix
@@ -13,7 +13,7 @@
 
 let
 
-  packageVersion = with builtins; (fromTOML (readFile "${source}/Cargo.toml")).package.version;
+  packageVersion = with builtins; (fromTOML (readFile ./Cargo.toml)).package.version;
 
   # append git revision to the version string, if available
   versionSuffix =
@@ -33,35 +33,37 @@ hydra-check.overrideAttrs (
     meta ? { },
     ...
   }@_prevAttrs:
-  if isDevShell then
-    {
-      # prevent devShell dependence on the source
-      src = emptyDirectory;
-      cargoDeps = emptyDirectory;
-    }
-  else
-    {
-      version =
-        assert lib.assertMsg (lib.versionAtLeast newVersion version) ''
-          hydra-check provided here (${newVersion}) failed to be newer
-          than the one provided in nixpkgs (${version}).
-        '';
-        newVersion;
+  (
+    if isDevShell then
+      {
+        # prevent devShell dependence on the source
+        src = emptyDirectory;
+        cargoDeps = emptyDirectory;
+      }
+    else
+      {
+        src = source;
+        cargoDeps = rustPlatform.importCargoLock {
+          lockFile = "${source}/Cargo.lock";
+        };
+      }
+  )
+  // {
+    version =
+      assert lib.assertMsg (lib.versionAtLeast newVersion version) ''
+        hydra-check provided here (${newVersion}) failed to be newer
+        than the one provided in nixpkgs (${version}).
+      '';
+      newVersion;
 
-      src = source;
-
-      cargoDeps = rustPlatform.importCargoLock {
-        lockFile = "${source}/Cargo.lock";
-      };
-
-      meta = meta // {
-        maintainers = with lib.maintainers; [
-          makefu
-          artturin
-          bryango
-        ];
-        # to correctly generate meta.position for backtrace:
-        inherit (meta) description;
-      };
-    }
+    meta = meta // {
+      maintainers = with lib.maintainers; [
+        makefu
+        artturin
+        bryango
+      ];
+      # to correctly generate meta.position for backtrace:
+      inherit (meta) description;
+    };
+  }
 )


### PR DESCRIPTION
Haven't released in a long time! Although the diff looks big, there are not many minimal user facing changes. Generated by Github and refined by me:
## What's Changed
* feat(args):
	- allow empty --arch & print --short --json correctly https://github.com/nix-community/hydra-check/pull/77
	- prefer nixpkgs-XX.XX-darwin on darwin, and refactor https://github.com/nix-community/hydra-check/pull/84
	- minor improvements of query resolution & version caching https://github.com/nix-community/hydra-check/pull/88
* feat: allow overriding hydra host URL in https://github.com/nix-community/hydra-check/pull/82
* refactor(eval): mv EvalStatus to structs/ & expose in https://github.com/nix-community/hydra-check/pull/89
* fix(package.nix): correct versioning for nix build in https://github.com/nix-community/hydra-check/pull/90
* build(deps):
	- bump nixpkgs, improve ci, rename trunk -> unstable in various PRs
	- bump openssl from 0.10.70 to 0.10.72 by @dependabot[bot] in https://github.com/nix-community/hydra-check/pull/76
	- bump actions/checkout from 4 to 6 by @dependabot[bot] in https://github.com/nix-community/hydra-check/pull/83, https://github.com/nix-community/hydra-check/pull/85
	- bump intel mac runner to macos-15 in https://github.com/nix-community/hydra-check/pull/86

**Full Changelog**: https://github.com/nix-community/hydra-check/compare/v2.0.4...master