### PR TITLE
fix(args): warn for --arch when querying evals

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -134,6 +134,12 @@ impl HydraCheckCli {
             }
         };
         if let Some(arch) = self.arch.clone() {
+            if self.eval || self.tests {
+                warn!(
+                    "--arch is mostly ignored when querying evals; {}",
+                    "consider specifying --channel or --jobset instead"
+                );
+            }
             // allow empty `--arch` as it may be the user's intention to
             // specify architectures explicitly for each package
             if !arch.is_empty() {


### PR DESCRIPTION
Closes #91. 

Direct users to use `--channel` instead of `--arch` when querying evaluations, because in this case `--arch` does not make much sense (as one eval usually contains packages for multiple architectures). See also https://github.com/nix-community/hydra-check/issues/91#issuecomment-3795904271.