### PR TITLE
build(release): v2.1.0 with minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ runs
 /.mypy_cache/
 /*.egg-info/
 /.direnv/
+.DS_Store
 
 # Nix
 /**/result*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,7 +779,7 @@ checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "hydra-check"
-version = "2.0.5"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,4 +47,4 @@ match_bool = "allow"
 single_match = "allow"
 single_match_else = "allow"
 missing_errors_doc = "allow"
-multiple_crate_versions = "allow"
+multiple_crate_versions = "allow" # toggle to review dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydra-check"
-version = "2.0.5"
+version = "2.1.0"
 description = "Check hydra for the build status of a package"
 authors = ["Felix Richter <github@krebsco.de>", "Bryan Lai <bryanlais@gmail.com>"]
 edition = "2021"

--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767026758,
-        "narHash": "sha256-7fsac/f7nh/VaKJ/qm3I338+wAJa/3J57cOGpXi0Sbg=",
+        "lastModified": 1771423170,
+        "narHash": "sha256-K7Dg9TQ0mOcAtWTO/FX/FaprtWQ8BmEXTpLIaNRhEwU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "346dd96ad74dc4457a9db9de4f4f57dab2e5731d",
+        "rev": "bcc4a9d9533c033d806a46b37dc444f9b0da49dd",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
             nixfmt-rfc-style # for formatting nix code
           ] ++ nativeBuildInputs;
 
-          env = with pkgs.buildPackages; env // {
+          env = with pkgs.buildPackages; (removeAttrs env ["RUST_LOG"]) // {
             # for developments, e.g. symbol lookup in std library
             RUST_SRC_PATH = "${rustPlatform.rustLibSrc}";
             # for debugging

--- a/flake.nix
+++ b/flake.nix
@@ -10,8 +10,15 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
       in
@@ -21,24 +28,40 @@
           default = self.packages.${system}.hydra-check;
         };
 
-        devShells.default = (self.packages.${system}.hydra-check.override {
-          # prevent dependence on the source ./.; see ./package.nix
-          source = null;
-        }).overrideAttrs ({ nativeBuildInputs ? [], env ? {}, ... }: {
-          nativeBuildInputs = with pkgs.buildPackages; [
-            git
-            cargo # with shell completions, instead of cargo-auditable
-            cargo-insta # for updating insta snapshots
-            clippy # more lints for better rust code
-            nixfmt-rfc-style # for formatting nix code
-          ] ++ nativeBuildInputs;
+        devShells.default =
+          (self.packages.${system}.hydra-check.override {
+            # prevent dependence on the source ./.; see ./package.nix
+            source = null;
+          }).overrideAttrs
+            (
+              {
+                nativeBuildInputs ? [ ],
+                env ? { },
+                ...
+              }:
+              {
+                nativeBuildInputs =
+                  with pkgs.buildPackages;
+                  [
+                    git
+                    cargo # with shell completions, instead of cargo-auditable
+                    cargo-insta # for updating insta snapshots
+                    clippy # more lints for better rust code
+                    nixfmt-rfc-style # for formatting nix code
+                  ]
+                  ++ nativeBuildInputs;
 
-          env = with pkgs.buildPackages; (removeAttrs env ["RUST_LOG"]) // {
-            # for developments, e.g. symbol lookup in std library
-            RUST_SRC_PATH = "${rustPlatform.rustLibSrc}";
-            # for debugging
-            RUST_LIB_BACKTRACE = "1";
-          };
-        });
-      });
+                env =
+                  with pkgs.buildPackages;
+                  (removeAttrs env [ "RUST_LOG" ])
+                  // {
+                    # for developments, e.g. symbol lookup in std library
+                    RUST_SRC_PATH = "${rustPlatform.rustLibSrc}";
+                    # for debugging
+                    RUST_LIB_BACKTRACE = "1";
+                  };
+              }
+            );
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,7 @@
                     cargo # with shell completions, instead of cargo-auditable
                     cargo-insta # for updating insta snapshots
                     clippy # more lints for better rust code
-                    nixfmt-rfc-style # for formatting nix code
+                    nixfmt # for formatting nix code
                   ]
                   ++ nativeBuildInputs;
 

--- a/release.sh
+++ b/release.sh
@@ -22,6 +22,6 @@ git commit -m "build(release): v${NEWVERSION}"
 # push & tag
 set -x
 CURRENT_BRANCH="$(git branch --show-current)"
-REMOTE=$(git remote --verbose | grep "REPO" | uniq)
+REMOTE=$(git remote --verbose | grep "$REPO" | uniq)
 git push "$REMOTE" "$CURRENT_BRANCH"
 gh release --repo "$REPO" create "v${NEWVERSION}" -t "v${NEWVERSION}" --prerelease --target "$CURRENT_BRANCH" --generate-notes

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,4 @@
-use clap::{arg, builder::ArgPredicate, command, value_parser, CommandFactory, Parser};
+use clap::{builder::ArgPredicate, value_parser, CommandFactory, Parser};
 use clap_complete::Shell;
 use flexi_logger::Logger;
 use log::{debug, error, warn};

--- a/src/queries/builds.rs
+++ b/src/queries/builds.rs
@@ -34,7 +34,6 @@ impl FetchHydraReport for BuildReport {
 }
 
 impl BuildReport {
-    #[must_use]
     pub(super) fn from_url(url: &str) -> Self {
         Self {
             url: url.to_string(),


### PR DESCRIPTION
- The main feature of this release is #78
- The diff is large only because flake.nix is reformatted with nixfmt
- There are some minor style tweaks to satisfy cargo clippy